### PR TITLE
Add image crawler script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # crawling
 
-https://www.cbe.go.kr/news/na/ntt/selectNttList.do?mi=10308&bbsId=1165
+This repository provides a script that downloads all images from the
+[Chungbuk Education Office](https://www.cbe.go.kr) board. The URL to crawl is:
 
-여기에 있는 사진을 전부 크롤링 하는데 구조를 직접 파악해야함.
+```
+https://www.cbe.go.kr/news/na/ntt/selectNttList.do?mi=10308&bbsId=1165
+```
+
+The script and usage instructions are organized in the `image_crawler` folder.
+Check the folder's README for setup details.

--- a/image_crawler/README.md
+++ b/image_crawler/README.md
@@ -1,0 +1,26 @@
+# Image Crawler
+
+This folder contains a simple Python script for crawling images from the
+[Chungbuk Education Office](https://www.cbe.go.kr) board list. The script
+finds all post links on the given list page and then downloads every image
+found in those posts.
+
+## Setup
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the crawler with the URL from the root `README.md`:
+
+```bash
+python crawler.py "https://www.cbe.go.kr/news/na/ntt/selectNttList.do?mi=10308&bbsId=1165"
+```
+
+Specify an output directory with `-o` to store downloaded images.

--- a/image_crawler/crawler.py
+++ b/image_crawler/crawler.py
@@ -1,0 +1,79 @@
+import os
+import re
+import argparse
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_html(url):
+    """Return HTML content of given URL."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def extract_article_links(list_url, html):
+    """Extract links to article pages from list page HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    links = []
+    for a in soup.find_all("a", href=True):
+        href = a['href']
+        if re.search(r'selectNttInfo', href):
+            links.append(urljoin(list_url, href))
+    return links
+
+
+def extract_image_urls(page_url, html):
+    """Extract image URLs from an article page."""
+    soup = BeautifulSoup(html, "html.parser")
+    images = []
+    for img in soup.find_all("img", src=True):
+        img_url = urljoin(page_url, img['src'])
+        images.append(img_url)
+    return images
+
+
+def download_file(url, dest_folder):
+    """Download a single file into destination folder."""
+    os.makedirs(dest_folder, exist_ok=True)
+    name = os.path.basename(urlparse(url).path)
+    if not name:
+        name = 'image'
+    dest = os.path.join(dest_folder, name)
+    resp = requests.get(url, stream=True)
+    resp.raise_for_status()
+    with open(dest, 'wb') as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+    return dest
+
+
+def crawl_images(list_url, output_dir='images'):
+    """Crawl all images from a list page and its articles."""
+    list_html = fetch_html(list_url)
+    article_links = extract_article_links(list_url, list_html)
+    image_urls = []
+    for link in article_links:
+        article_html = fetch_html(link)
+        image_urls.extend(extract_image_urls(link, article_html))
+    for img_url in image_urls:
+        try:
+            path = download_file(img_url, output_dir)
+            print(f"Downloaded {img_url} -> {path}")
+        except Exception as e:
+            print(f"Failed {img_url}: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Crawl images from a CBE board list page")
+    parser.add_argument('url', help='List page URL')
+    parser.add_argument('-o', '--output', default='images', help='Output directory for images')
+    args = parser.parse_args()
+    crawl_images(args.url, args.output)
+
+
+if __name__ == '__main__':
+    main()

--- a/image_crawler/requirements.txt
+++ b/image_crawler/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- implement `image_crawler/crawler.py` to scrape article links and download images
- document how to use the script in `image_crawler/README.md`
- update root README with crawler info

## Testing
- `pip install -r image_crawler/requirements.txt` *(fails: Tunnel connection failed)*
- `python image_crawler/crawler.py "https://www.cbe.go.kr/news/na/ntt/selectNttList.do?mi=10308&bbsId=1165" -o tmp_images` *(fails: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68775ed80c488324b58901cfc251eb75