### PR TITLE
Add generic image crawler

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # crawling
 
-This repository provides a script that downloads all images from the
-[Chungbuk Education Office](https://www.cbe.go.kr) board. The URL to crawl is:
+This repository contains image crawling utilities. The original script focuses
+on downloading all images from the [Chungbuk Education Office](https://www.cbe.go.kr) board:
 
 ```
 https://www.cbe.go.kr/news/na/ntt/selectNttList.do?mi=10308&bbsId=1165
 ```
 
-The script and usage instructions are organized in the `image_crawler` folder.
-Check the folder's README for setup details.
+The code for that crawler resides in the `image_crawler` folder.
+
+A more general crawler that follows links within any domain and stores the
+results in a ZIP file is provided in the `domain_image_crawler` folder.
+Check each folder's README for setup and usage details.

--- a/domain_image_crawler/README.md
+++ b/domain_image_crawler/README.md
@@ -1,0 +1,27 @@
+# Domain Image Crawler
+
+This folder contains a script to crawl images from any given domain. The
+crawler starts from the provided URL, follows internal links and downloads all
+images it encounters. Once crawling completes the images are optionally zipped
+for easy storage or transfer.
+
+## Setup
+
+Create a virtual environment and install the dependencies:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the crawler with a starting URL. Use `--zip` to store the downloaded images
+as a ZIP file.
+
+```bash
+python crawler.py https://example.com --zip images.zip
+```
+
+Use `--max-pages` to limit how many pages of the domain are visited.

--- a/domain_image_crawler/crawler.py
+++ b/domain_image_crawler/crawler.py
@@ -1,0 +1,114 @@
+import argparse
+import os
+import re
+from collections import deque
+from urllib.parse import urljoin, urlparse
+from zipfile import ZipFile
+
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_html(url):
+    """Return HTML content of given URL."""
+    resp = requests.get(url)
+    resp.raise_for_status()
+    return resp.text
+
+
+def extract_links(page_url, html, domain):
+    """Extract in-domain links from page HTML."""
+    soup = BeautifulSoup(html, "html.parser")
+    links = []
+    for a in soup.find_all("a", href=True):
+        href = urljoin(page_url, a["href"])
+        if urlparse(href).netloc == domain:
+            links.append(href)
+    return links
+
+
+def extract_image_urls(page_url, html):
+    """Extract image URLs from a page."""
+    soup = BeautifulSoup(html, "html.parser")
+    images = []
+    for img in soup.find_all("img", src=True):
+        img_url = urljoin(page_url, img["src"])
+        images.append(img_url)
+    return images
+
+
+def download_file(url, dest_folder):
+    """Download a single file into destination folder."""
+    os.makedirs(dest_folder, exist_ok=True)
+    name = os.path.basename(urlparse(url).path)
+    if not name:
+        name = "image"
+    dest = os.path.join(dest_folder, name)
+    resp = requests.get(url, stream=True)
+    resp.raise_for_status()
+    with open(dest, "wb") as f:
+        for chunk in resp.iter_content(chunk_size=8192):
+            if chunk:
+                f.write(chunk)
+    return dest
+
+
+def zip_dir(directory, zip_path):
+    """Compress directory into a ZIP file."""
+    with ZipFile(zip_path, "w") as zf:
+        for root, _, files in os.walk(directory):
+            for f in files:
+                abs_path = os.path.join(root, f)
+                arc_name = os.path.relpath(abs_path, directory)
+                zf.write(abs_path, arc_name)
+
+
+def crawl_domain(start_url, output_dir="images", max_pages=10, zip_file=None):
+    """Crawl images from pages within the same domain."""
+    domain = urlparse(start_url).netloc
+    visited = set()
+    queue = deque([start_url])
+    images = []
+
+    while queue and len(visited) < max_pages:
+        url = queue.popleft()
+        if url in visited:
+            continue
+        visited.add(url)
+        try:
+            html = fetch_html(url)
+        except Exception as e:
+            print(f"Failed to fetch {url}: {e}")
+            continue
+        images.extend(extract_image_urls(url, html))
+        for link in extract_links(url, html, domain):
+            if link not in visited and len(visited) + len(queue) < max_pages:
+                queue.append(link)
+
+    downloaded = []
+    for img_url in images:
+        try:
+            path = download_file(img_url, output_dir)
+            downloaded.append(path)
+            print(f"Downloaded {img_url} -> {path}")
+        except Exception as e:
+            print(f"Failed {img_url}: {e}")
+
+    if zip_file:
+        zip_dir(output_dir, zip_file)
+        print(f"Saved images to {zip_file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Crawl images from a domain")
+    parser.add_argument("url", help="Starting URL")
+    parser.add_argument("-o", "--output", default="images", help="Output directory")
+    parser.add_argument("--zip", help="ZIP file path for downloaded images")
+    parser.add_argument("--max-pages", type=int, default=10, help="Maximum pages to visit")
+    args = parser.parse_args()
+
+    crawl_domain(args.url, args.output, args.max_pages, args.zip)
+
+
+if __name__ == "__main__":
+    main()

--- a/domain_image_crawler/requirements.txt
+++ b/domain_image_crawler/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- generalize crawling with new script `domain_image_crawler/crawler.py`
- document new crawler usage and requirements
- update repository README with overview of both crawlers

## Testing
- `python -m pip install -r image_crawler/requirements.txt -r domain_image_crawler/requirements.txt`
- `python -m py_compile domain_image_crawler/crawler.py image_crawler/crawler.py`
- `python domain_image_crawler/crawler.py https://www.python.org --max-pages 1 --zip test_images.zip`

------
https://chatgpt.com/codex/tasks/task_e_6877606d64e88324b95fb74d1f8064ed